### PR TITLE
BulletinBoard - async role helpers

### DIFF
--- a/ProjektyStudentow/2017_KulewskiKrzysztof/BulletinBoard/Controllers/JobCategoryController.cs
+++ b/ProjektyStudentow/2017_KulewskiKrzysztof/BulletinBoard/Controllers/JobCategoryController.cs
@@ -111,7 +111,7 @@ namespace BulletinBoard.Controllers
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!JobCategoryExists(model.JobCategoryId))
+                if (!await JobCategoryExists(model.JobCategoryId))
                 {
                     return View("NotFound");
                 }
@@ -158,9 +158,9 @@ namespace BulletinBoard.Controllers
             return RedirectToAction(nameof(Index));
         }
 
-        private bool JobCategoryExists(string id)
+        private async Task<bool> JobCategoryExists(string id)
         {
-            return _context.JobCategories.Any(e => e.JobCategoryId == id);
+            return await _context.JobCategories.AnyAsync(e => e.JobCategoryId == id);
         }
     }
 }

--- a/ProjektyStudentow/2017_KulewskiKrzysztof/BulletinBoard/Controllers/JobOfferController.cs
+++ b/ProjektyStudentow/2017_KulewskiKrzysztof/BulletinBoard/Controllers/JobOfferController.cs
@@ -59,8 +59,8 @@ namespace BulletinBoard.Controllers
                 foreach (var offer in jobOffers)
                 {
                     offer.CanEdit = offer.Author.Id == user.Id
-                                    || await UserIsAdministrator()
-                                    || await UserIsModerator();
+                                    || await IsUserAdministrator()
+                                    || await IsUserModerator();
                 }
             }
 
@@ -96,8 +96,8 @@ namespace BulletinBoard.Controllers
                 foreach (var offer in jobOffers)
                 {
                     offer.CanEdit = offer.Author.Id == user.Id
-                                    || await UserIsAdministrator()
-                                    || await UserIsModerator();
+                                    || await IsUserAdministrator()
+                                    || await IsUserModerator();
                 }
             }
 
@@ -150,7 +150,7 @@ namespace BulletinBoard.Controllers
                 var user = await GetCurrentUser();
 
                 // make each offer edit-able when user is its author OR admin/moderator
-                viewModel.CanEdit = (viewModel.Author.Id == user.Id) || await UserIsAdministrator() || await UserIsModerator();
+                viewModel.CanEdit = (viewModel.Author.Id == user.Id) || await IsUserAdministrator() || await IsUserModerator();
             }
 
             return View(viewModel);
@@ -215,7 +215,7 @@ namespace BulletinBoard.Controllers
                 return View("NotFound");
             }
 
-            if (jobOffer.Author.Id != (await GetCurrentUser()).Id && !await UserIsModerator() && !await UserIsAdministrator())
+            if (jobOffer.Author.Id != (await GetCurrentUser()).Id && !await IsUserModerator() && !await IsUserAdministrator())
             {
                 return View("AccessDenied");
             }
@@ -325,13 +325,13 @@ namespace BulletinBoard.Controllers
             return await _userManager.GetUserAsync(User);
         }
 
-        private async Task<bool> UserIsModerator()
+        private async Task<bool> IsUserModerator()
         {
             var user = await GetCurrentUser();
             return await _userManager.IsInRoleAsync(user, RoleHelper.Moderator);
         }
 
-        private async Task<bool> UserIsAdministrator()
+        private async Task<bool> IsUserAdministrator()
         {
             var user = await GetCurrentUser();
             return await _userManager.IsInRoleAsync(user, RoleHelper.Administrator);

--- a/ProjektyStudentow/2017_KulewskiKrzysztof/BulletinBoard/Controllers/JobTypeController.cs
+++ b/ProjektyStudentow/2017_KulewskiKrzysztof/BulletinBoard/Controllers/JobTypeController.cs
@@ -111,7 +111,7 @@ namespace BulletinBoard.Controllers
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!JobTypeExists(model.JobTypeId))
+                if (!await JobTypeExists(model.JobTypeId))
                 {
                     return View("NotFound");
                 }
@@ -158,9 +158,9 @@ namespace BulletinBoard.Controllers
             return RedirectToAction(nameof(Index));
         }
 
-        private bool JobTypeExists(string id)
+        private async Task<bool> JobTypeExists(string id)
         {
-            return _context.JobTypes.Any(e => e.JobTypeId == id);
+            return await _context.JobTypes.AnyAsync(e => e.JobTypeId == id);
         }
     }
 }

--- a/ProjektyStudentow/2017_KulewskiKrzysztof/BulletinBoard/Program.cs
+++ b/ProjektyStudentow/2017_KulewskiKrzysztof/BulletinBoard/Program.cs
@@ -10,9 +10,11 @@ namespace BulletinBoard
             BuildWebHost(args).Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
+        public static IWebHost BuildWebHost(string[] args)
+        {
+            return WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 .Build();
+        }
     }
 }


### PR DESCRIPTION
Metody pomocnicze dotyczące ról użytkownika (używane do określania, czy dany VM powinien być edytowalny przez zalogowanego użytkownika) działały synchronicznie - uznałem, że wypada to zmienić.

Powinien powstać z nich osobny serwis, który potrafiłby to cache'ować (zamiast za każdym razem strzelać do bazy), ale to chyba overkill jak na taki projekt.

Chętnie też usłyszałbym opinię odnośnie linii 115 do 120 w JobOfferController - może powinienem najpierw wywołać ToListAsync (dodać w 118 linii), zanim zacznę mapować modele na VM?
